### PR TITLE
Harden broker and CLI data contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ This changelog follows the Keep a Changelog style.
   release UX, stronger automation guidance, better project discoverability,
   and more explicit coverage of flexible single-asset to whole-universe
   workflows.
+- Added an optional `parquet` extra for installing `pyarrow` alongside the
+  base package.
 
 ### Fixed
 - Correct short-position closed-trade accounting so entry/exit semantics are
@@ -65,6 +67,12 @@ This changelog follows the Keep a Changelog style.
   JSON.
 - `Engine.run(...)` now raises an explicit error if end-of-run liquidation
   leaves positions open.
+- Good-till-cancel orders now remain pending when a ticker is temporarily
+  missing from the current bar instead of being dropped immediately.
+- Engine/CLI market-data validation now rejects MultiIndex inputs with extra
+  levels instead of accepting shapes the broker cannot process.
+- CLI parquet input now fails with a clean actionable error when no parquet
+  engine is installed.
 
 ### Removed
 - Removed legacy `purchase_*` and `selling_*` `ClosedPosition` fields/aliases.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Install with `pip`:
 pip install kissbt
 ```
 
+Install with parquet support:
+
+```sh
+pip install "kissbt[parquet]"
+```
+
 Install with `uv`:
 
 ```sh
@@ -116,13 +122,13 @@ Why those numbers:
 Two additional behaviors matter in practice:
 
 - If a held ticker disappears from the current universe, `Broker.update(...)` closes it at the previous bar `close`
-- Good-till-cancel orders remain pending until they fill or the run ends
+- Good-till-cancel orders remain pending across later bars when unfilled, including when a ticker is temporarily missing
 
 ## Input Data Requirements
 
 `Engine.run(data)` expects a pandas `DataFrame` with:
 
-- MultiIndex named `("timestamp", "ticker")`
+- Exactly two index levels named `("timestamp", "ticker")`
 - Unique `("timestamp", "ticker")` rows
 - Required columns: `open`, `close`
 - Additional columns for `LIMIT` orders: `high`, `low`
@@ -232,6 +238,9 @@ kissbt backtest \
   --input tests/data/tech_stocks.parquet \
   --strategy my_strategies.golden_cross:GoldenCrossStrategy
 ```
+
+Parquet input requires an installed parquet engine such as `pyarrow`. The
+`kissbt[parquet]` extra installs that dependency for you.
 
 Useful flags:
 

--- a/kissbt/_market_data_validation.py
+++ b/kissbt/_market_data_validation.py
@@ -24,7 +24,7 @@ def validate_market_data_frame(
         )
 
     names = list(data.index.names)
-    if len(names) < 2 or names[0] != "timestamp" or names[1] != "ticker":
+    if len(names) != 2 or names != ["timestamp", "ticker"]:
         raise ValueError(
             f"{context} index must be a MultiIndex named ['timestamp', 'ticker']"
         )

--- a/kissbt/broker.py
+++ b/kissbt/broker.py
@@ -441,11 +441,9 @@ class Broker:
 
         # buy and sell assets
         remaining_open_orders = []
-        ticker_not_available = set(
-            [open_order.ticker for open_order in self._open_orders]
-        ) - set(self._current_bar.index)
+        current_tickers = set(self._current_bar.index)
         for open_order in self._open_orders:
-            if open_order.ticker in ticker_not_available:
+            if open_order.ticker not in current_tickers:
                 side = "buy" if open_order.size > 0 else "sell"
                 self._record_event(
                     "order_unfilled_ticker_missing",
@@ -455,6 +453,8 @@ class Broker:
                     side=side,
                     order_type=open_order.order_type.value,
                 )
+                if open_order.good_till_cancel:
+                    remaining_open_orders.append(open_order)
                 continue
             if (
                 not self._execute_order(

--- a/kissbt/cli.py
+++ b/kissbt/cli.py
@@ -38,6 +38,17 @@ def _sanitize_for_json(value: Any) -> Any:
     return value
 
 
+def _read_parquet(input_path: Path) -> pd.DataFrame:
+    try:
+        return pd.read_parquet(input_path)
+    except ImportError as exc:
+        raise ValueError(
+            "failed to read parquet input data from "
+            f"'{input_path}': install 'pyarrow' or use the "
+            "'kissbt[parquet]' extra"
+        ) from exc
+
+
 def _load_market_data(input_path: Path, input_format: str) -> pd.DataFrame:
     detected_format = input_format
     if detected_format == "auto":
@@ -48,7 +59,7 @@ def _load_market_data(input_path: Path, input_format: str) -> pd.DataFrame:
 
     try:
         if detected_format == "parquet":
-            data = pd.read_parquet(input_path)
+            data = _read_parquet(input_path)
         elif detected_format == "csv":
             data = pd.read_csv(input_path)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
 requires-python = ">=3.12,<3.15"
 
 [project.optional-dependencies]
+parquet = [
+    "pyarrow",
+]
 dev = [
     "pytest",
     "pytest-mock",

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -538,6 +538,33 @@ def test_update_records_unfilled_ticker_missing_event(broker):
     assert event["type"] == "order_unfilled_ticker_missing"
     assert event["ticker"] == "AAPL"
     assert event["side"] == "buy"
+    assert broker._open_orders == []
+
+
+def test_update_retains_good_till_cancel_order_when_ticker_missing(broker):
+    order = Order("AAPL", 10, OrderType.OPEN, good_till_cancel=True)
+    broker.place_order(order)
+
+    broker.update(
+        pd.DataFrame(
+            {"open": [100], "high": [101], "low": [99], "close": [100]}, index=["MSFT"]
+        ),
+        pd.Timestamp("2024-01-01"),
+    )
+
+    assert broker.events[0]["type"] == "order_unfilled_ticker_missing"
+    assert broker._open_orders == [order]
+
+    broker.update(
+        pd.DataFrame(
+            {"open": [110], "high": [111], "low": [109], "close": [110]},
+            index=["AAPL"],
+        ),
+        pd.Timestamp("2024-01-02"),
+    )
+
+    assert broker._open_orders == []
+    assert broker.open_positions["AAPL"].size == 10
 
 
 def test_execute_order_records_executed_event(broker):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,3 +162,34 @@ def test_cli_backtest_prints_clean_error_for_invalid_csv(tmp_path, capsys):
     assert exc_info.value.code == 1
     assert "Error: failed to parse CSV input data from" in captured.err
     assert "Traceback" not in captured.err
+
+
+def test_cli_backtest_prints_clean_error_for_missing_parquet_engine(
+    tmp_path, monkeypatch, capsys
+):
+    parquet_path = tmp_path / "market_data.parquet"
+    parquet_path.write_bytes(b"PAR1")
+
+    def _raise_missing_engine(_path):
+        raise ImportError("Unable to find a usable engine")
+
+    monkeypatch.setattr(pd, "read_parquet", _raise_missing_engine)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "backtest",
+                "--input",
+                str(parquet_path),
+                "--input-format",
+                "parquet",
+                "--strategy",
+                "unused:Strategy",
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "Error: failed to read parquet input data from" in captured.err
+    assert "kissbt[parquet]" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -132,6 +132,23 @@ def test_run_rejects_wrong_multiindex_names():
         engine.run(data)
 
 
+def test_run_rejects_extra_multiindex_level():
+    broker = Broker()
+    strategy = DummyStrategy(broker)
+    engine = Engine(broker=broker, strategy=strategy)
+    data = _build_valid_data().copy()
+    data.index = pd.MultiIndex.from_tuples(
+        [
+            (pd.Timestamp("2024-01-01"), "AAPL", "XNAS"),
+            (pd.Timestamp("2024-01-02"), "AAPL", "XNAS"),
+        ],
+        names=["timestamp", "ticker", "exchange"],
+    )
+
+    with pytest.raises(ValueError, match="data index must be a MultiIndex"):
+        engine.run(data)
+
+
 def test_run_rejects_missing_required_columns():
     broker = Broker()
     strategy = DummyStrategy(broker)

--- a/uv.lock
+++ b/uv.lock
@@ -339,6 +339,9 @@ dev = [
     { name = "ruff" },
     { name = "yfinance" },
 ]
+parquet = [
+    { name = "pyarrow" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -347,13 +350,14 @@ requires-dist = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pyarrow", marker = "extra == 'dev'" },
+    { name = "pyarrow", marker = "extra == 'parquet'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-mock", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scipy" },
     { name = "yfinance", marker = "extra == 'dev'" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["parquet", "dev"]
 
 [[package]]
 name = "kiwisolver"


### PR DESCRIPTION
## Summary
- keep good-till-cancel orders pending when a ticker is temporarily missing from a bar
- reject market data with extra MultiIndex levels that the engine cannot process correctly
- surface a clean parquet-engine error in the CLI and document the optional parquet extra

## Testing
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy kissbt tests
- uv run pytest -q