### PR TITLE
Update package license metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This changelog follows the Keep a Changelog style.
 ### Changed
 - `ClosedPosition` now uses `entry_price`, `entry_timestamp`, `exit_price`,
   `exit_timestamp` as canonical trade lifecycle fields.
+- Package metadata now uses SPDX license metadata compatible with current
+  setuptools packaging guidance.
 - Analyzer win-rate and profit-factor calculations now use
   `ClosedPosition.pnl`.
 - `Broker.history` now returns copies of its value lists instead of exposing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,13 @@ authors = [
 maintainers = [
     { name = "Adrian Hasse", email = "adrian.hasse@finblobs.com" }
 ]
-license = { file = "LICENSE" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent"
 ]
 dependencies = [


### PR DESCRIPTION
## Summary
- switch package metadata to SPDX license fields in pyproject.toml
- remove the deprecated license classifier and keep LICENSE included via license-files
- add an Unreleased changelog note for the packaging metadata update

## Verification
- uv run --with build python -m build
